### PR TITLE
Bind start script to all interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "astro build",
     "dev": "astro dev --host 0.0.0.0 --port 4321",
     "preview": "astro preview",
-    "start": "astro dev",
+    "start": "astro dev --host 0.0.0.0 --port 4321",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"


### PR DESCRIPTION
## Summary
- Update the `start` script to bind Astro dev to `0.0.0.0` on port `4321`.
- Makes `bun run start` reachable from another device on the network, matching the existing `dev` script behavior.

## Testing
- `bun run format:check`